### PR TITLE
added Clp as default solver, always specify solver to JuMP.Model()

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ LightGraphs 0.9.0
 JuMP 0.13.2
 MatrixDepot
 BlossomV 0.1
+Clp 0.3.1

--- a/src/matching/lp.jl
+++ b/src/matching/lp.jl
@@ -32,7 +32,7 @@ function maximum_weight_maximal_matching{T<:Real}(g::Graph, w::Dict{Edge,T}, cut
 end
 
 
-function maximum_weight_maximal_matching{T<:Real}(g::Graph, w::Dict{Edge,T})
+function maximum_weight_maximal_matching{T<:Real}(g::Graph, w::Dict{Edge,T}, solver = ClpSolver)
 # TODO support for graphs with zero degree nodes
 # TODO apply separately on each connected component
     bpmap = bipartite_map(g)
@@ -51,7 +51,7 @@ function maximum_weight_maximal_matching{T<:Real}(g::Graph, w::Dict{Edge,T})
         edgemap[reverse(e)] = nedg
     end
 
-    model = Model()
+    model = Model(solver=solver())
     @variable(model, x[1:length(w)] >= 0)
 
     for i in v1

--- a/src/matching/matching.jl
+++ b/src/matching/matching.jl
@@ -24,6 +24,8 @@ end
 import BlossomV
 include("blossomv.jl")
 
+using Clp: ClpSolver
+
 using JuMP
 include("lp.jl")
 include("maximum_weight_matching.jl")

--- a/src/matching/maximum_weight_matching.jl
+++ b/src/matching/maximum_weight_matching.jl
@@ -22,9 +22,10 @@ Returns MatchingResult containing:
 function maximum_weight_matching end
 
 function maximum_weight_matching{T <:Real}(g::Graph,
-          w::Dict{Edge,T} = Dict{Edge,Int64}(i => 1 for i in collect(edges(g))))
+          w::Dict{Edge,T} = Dict{Edge,Int64}(i => 1 for i in collect(edges(g))),
+          solver = ClpSolver)
 
-    model = Model()
+    model = Model(solver = solver())
     n = nv(g)
     edge_list = collect(edges(g))
 


### PR DESCRIPTION
This removes the error from JuMP requiring a LP solver to the problem