### PR TITLE
Fixes for julia v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
 #  - osx
 
 julia:
- - 0.6
+ - 0.7
+ - 1.0
  - nightly
 
 matrix:
@@ -15,13 +16,13 @@ matrix:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("LightGraphsExtras"); Pkg.test("LightGraphsExtras"; coverage=true)'
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("LightGraphsExtras"); Pkg.test("LightGraphsExtras"; coverage=true)'
 
 # cache:
 #   directories:
 #     - $HOME/.julia/v0.4/JuMP/
 #     - $HOME/.julia/v0.5/JuMP/
 after_success:
-    - julia -e 'cd(Pkg.dir("LightGraphsExtras")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+    - julia -e 'cd(using Pkg; Pkg.dir("LightGraphsExtras")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,7 @@
-julia 0.6
-LightGraphs 0.9.0
-JuMP 0.13.2
+julia 0.7
+LightGraphs 1.1.0
+JuMP 0.18.3
 MatrixDepot
-GLPKMathProgInterface 0.3.2
+GLPKMathProgInterface 0.4.4
+MathProgBase 0.7.6
+LightGraphsFlows

--- a/src/datasets/datasets.jl
+++ b/src/datasets/datasets.jl
@@ -1,7 +1,6 @@
-__precompile__(true)
 module Datasets
 
-using ...LightGraphs
+using LightGraphs
 using MatrixDepot
 
 # matrixdepot

--- a/src/datasets/matrixdepot.jl
+++ b/src/datasets/matrixdepot.jl
@@ -1,7 +1,7 @@
 function MDGraph(a::AbstractString, x...)
     a in matrixdepot("symmetric") || error("Valid matrix not found in collection")
     external = a in matrixdepot("data")
-    m = external? matrixdepot(a, x..., :read) : matrixdepot(a, x...)
+    m = external ? matrixdepot(a, x..., :read) : matrixdepot(a, x...)
     m == nothing && error("Invalid matrix parameters specified")
 
     return Graph(m)
@@ -10,7 +10,7 @@ end
 function MDDiGraph(a::AbstractString, x...)
     a in matrixdepot("all") || error("Valid matrix not found in collection")
     external = a in matrixdepot("data")
-    m = external? matrixdepot(a, x..., :read) : matrixdepot(a, x...)
+    m = external ? matrixdepot(a, x..., :read) : matrixdepot(a, x...)
     m == nothing && error("Invalid matrix parameters specified")
 
     return DiGraph(m)

--- a/src/interdiction/bilevel_adaptive_arc.jl
+++ b/src/interdiction/bilevel_adaptive_arc.jl
@@ -18,9 +18,9 @@ function init_first_level_arc(
 	# flow conservation constraints
 	for v in vertices(flow_graph)
 		if (v ≠ source && v ≠ target)
-      @constraint(first_level, sum{x[i, j], i = 1:n, j = 1:n;
-        capacity_matrix[i ,j] > 0} - sum{x[j, i], i = 1:n, j = 1:n;
-        capacity_matrix[j, i] > 0} == 0)
+      @constraint(first_level, sum(x[i, j] for i = 1:n, j = 1:n if
+        capacity_matrix[i ,j] > 0) - sum(x[j, i] for i = 1:n, j = 1:n if
+        capacity_matrix[j, i] > 0) == 0)
 	   	end
 	end
 
@@ -55,9 +55,9 @@ function init_second_level_arc(
   @variable(second_level, ν[i = 1:n, j = 1:n] ≥ 0)
 
   # set objective
-  @objective(second_level, Min, sum{
-    x_value[i, j] * δ[i, j] - x_value[i, j] * ν[i, j], i = 1:n, j = 1:n;
-    capacity_matrix[i, j] > 0})
+  @objective(second_level, Min, sum(
+    x_value[i, j] * δ[i, j] - x_value[i, j] * ν[i, j] for i = 1:n, j = 1:n if
+    capacity_matrix[i, j] > 0))
 
   # constraints over the edges
   for e in edges(flow_graph)
@@ -85,7 +85,7 @@ function init_second_level_arc(
   end
 
   # constraint on the upper bound for the number of attacks
-  @constraint(second_level, sum{μ[i, j], i = 1:n, j = 1:n} ≤ attacks)
+  @constraint(second_level, sum(μ[i, j] for i = 1:n, j = 1:n) ≤ attacks)
 
   return second_level, δ, ν
 end
@@ -130,9 +130,9 @@ function bilevel_adaptive_arc(
     # Otherwise add the new cut to the first level
 		δ_value = getvalue(δ)
 		ν_value = getvalue(ν)
-    @constraint(first_level, z ≤ sum{
-      δ_value[i, j] * x[i, j] - ν_value[i, j] * x[i, j], i = 1:n, j = 1:n;
-      capacity_matrix[i, j] > 0})
+    @constraint(first_level, z ≤ sum(
+      δ_value[i, j] * x[i, j] - ν_value[i, j] * x[i, j] for i = 1:n, j = 1:n if
+      capacity_matrix[i, j] > 0))
   end
 
   # Return objective value and elapsed time

--- a/src/interdiction/interdiction.jl
+++ b/src/interdiction/interdiction.jl
@@ -1,15 +1,15 @@
-__precompile__(true)
 module Interdiction
 
 using LightGraphs
 using JuMP
 using MathProgBase
+using LightGraphsFlows
 
 using GLPKMathProgInterface: GLPKSolverMIP
 
 import MathProgBase.SolverInterface.AbstractMathProgSolver,
        JuMP.UnsetSolver,
-       LightGraphs.DefaultCapacity
+       LightGraphsFlows.DefaultCapacity
 
 export interdiction_flow, ⪷,
        NetworkInterdictionProblem, AdaptiveFlowArcProblem, AdaptiveFlowPathProblem,
@@ -202,14 +202,13 @@ use of the solver keyword, as it is similar to the `Model()` method there.
 
 All algorithms return a tuple with 1) a lower bound and 2) an upper bound.
 For the Multilink Attack algorithm, it also returns the restriction values (to use with
-the function maximum_flow in LightGraphs.jl) associated with 3-a) the lower bound and
+the function maximum_flow in LightGraphsFlows.jl) associated with 3-a) the lower bound and
 4-a) the upper bound. When the BMILP is used, the third element returned is 3-b) the
 time used by the algorithm.
 
 When the number of attacks is set to -1, an array with the results for any possible number of attacks will be output. Each result will be output as above.
 
 """
-
 function interdiction_flow(
   flow_graph::DiGraph,                           # the input graph
   source::Int,                                   # the source vertex

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
-Clp
+Clp 0.5.0
+LightGraphsFlows

--- a/test/datasets/matrixdepot.jl
+++ b/test/datasets/matrixdepot.jl
@@ -1,3 +1,5 @@
+@testset "MatrixDepot" begin
+
 println("*** Running MatrixDepot tests")
 randstr = "LightGraphs/$(rand(1:10000))"
 g = MDGraph("hilb", 4)
@@ -8,3 +10,5 @@ g = MDDiGraph("baart", 4)
 
 @test_throws ErrorException MDGraph("baart", 4)
 println("*** Finished MatrixDepot tests")
+
+end

--- a/test/datasets/runtests.jl
+++ b/test/datasets/runtests.jl
@@ -3,8 +3,10 @@ tests = [
 ]
 
 
-for t in tests
-    tp = joinpath(testdir,"$(t).jl")
-    println("running $(tp) ...")
-    include(tp)
+@testset "datasets" begin
+    for t in tests
+            tp = joinpath(testdir,"$(t).jl")
+            println("running $(tp) ...")
+            include(tp)
+    end
 end

--- a/test/interdiction/runtests.jl
+++ b/test/interdiction/runtests.jl
@@ -1,6 +1,9 @@
-using Base.Test
+using Test
 using LightGraphs
 using LightGraphsExtras.Interdiction
+using LightGraphsFlows: maximum_flow
+
+@testset "interdiction" begin
 
 #### Graphs for testing
 graphs = [
@@ -81,5 +84,7 @@ for (nvertices, flow_edges, s, t) in graphs
   # Test when attacks = -1
   @test interdiction_flow(flow_graph, s, t, capacity_matrix)[2] ==
         interdiction_flow(flow_graph, s, t, capacity_matrix, 1)
+
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
-include("../src/LightGraphsExtras.jl")
 using LightGraphs
 using LightGraphsExtras
 using LightGraphsExtras.Datasets
 using LightGraphsExtras.Interdiction
-using Base.Test
+using Test
 
 testdir = dirname(@__FILE__)
 
@@ -12,8 +11,10 @@ tests = [
     "interdiction"
 ]
 
-for t in tests
-    tp = joinpath(testdir, t, "runtests.jl")
-    println("running $(tp) ...")
-    include(tp)
+@testset "LightGraphsExtras" begin
+    for t in tests
+            tp = joinpath(testdir, t, "runtests.jl")
+            println("running $(tp) ...")
+            include(tp)
+    end
 end


### PR DESCRIPTION
JuMP v0.8.3 is out, so it's possible now to have this package running in Julia v1.0.  
I had to add a dependency on `LightGraphsFlows.jl` because some code was previously moved to that package from this one